### PR TITLE
resolve inconsistent role licenses

### DIFF
--- a/configure_cluster/README.md
+++ b/configure_cluster/README.md
@@ -26,7 +26,7 @@ Including an example of how to use your role (for instance, with variables passe
 
 ## License
 
-BSD
+Apache 2.0
 
 ## Author Information
 

--- a/configure_cluster/meta/main.yml
+++ b/configure_cluster/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   # - GPL-3.0-only
   # - Apache-2.0
   # - CC-BY-4.0
-  license: GPL-3.0-only
+  license: Apache-2.0
 
   min_ansible_version: 2.1
 

--- a/generate_discovery_iso/meta/main.yml
+++ b/generate_discovery_iso/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   # - GPL-3.0-only
   # - Apache-2.0
   # - CC-BY-4.0
-  license: GPL-3.0-only
+  license: Apache-2.0
 
   min_ansible_version: 2.1
 

--- a/generate_rwn_iso/README.md
+++ b/generate_rwn_iso/README.md
@@ -26,7 +26,7 @@ Including an example of how to use your role (for instance, with variables passe
 
 ## License
 
-BSD
+Apache 2.0
 
 ## Author Information
 

--- a/generate_rwn_iso/meta/main.yml
+++ b/generate_rwn_iso/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   # - GPL-3.0-only
   # - Apache-2.0
   # - CC-BY-4.0
-  license: GPL-3.0-only
+  license: Apache-2.0
 
 
   min_ansible_version: 2.1


### PR DESCRIPTION
The repository as a whole is licensed under Apache-2.0.
However three roles (configure_cluster, generate_discovery_iso
and generate_rwn_iso) state GPL v3.0 in their meta `galaxy_info`,
and two of those also inconsistently state they are under BSD
license in their READMEs.

This change is a suggestion to re-license them all under
Apache 2.0 to match the repository as a whole, simplify the
license arrangements and avoid any confusion.